### PR TITLE
CP-2907: Update screen density type from int to float64

### DIFF
--- a/context.go
+++ b/context.go
@@ -121,9 +121,9 @@ type ReferrerInfo struct {
 // This type provides the representation of the `context.screen` object as
 // defined in https://segment.com/docs/spec/common/#context
 type ScreenInfo struct {
-	Density int `json:"density,omitempty"`
-	Width   int `json:"width,omitempty"`
-	Height  int `json:"height,omitempty"`
+	Density float64 `json:"density,omitempty"`
+	Width   int     `json:"width,omitempty"`
+	Height  int     `json:"height,omitempty"`
 }
 
 // Satisfy the `json.Marshaler` interface. We have to flatten out the `Extra`


### PR DESCRIPTION
Playground demo code: 

```package main

import (
	"encoding/json"
	"fmt"
)

type ScreenInfo struct {
	Density float64 `json:"density,omitempty"`
	Width   int     `json:"width,omitempty"`
	Height  int     `json:"height,omitempty"`
}

func testFunc() (ScreenInfo, error) {
	var json_event = []byte(`{"density": 3}`)
	var seg_body ScreenInfo

	err := json.Unmarshal(json_event, &seg_body)
	if err != nil {
		fmt.Println("there is an error")
	} else {
		fmt.Println(seg_body)
		fmt.Println("there is no error")
	}
	return seg_body, nil
}

func main() {
	testFunc()
}
```